### PR TITLE
Fix pos_vel_parsec bench's adding of position only entities

### DIFF
--- a/benches/pos_vel_parsec.rs
+++ b/benches/pos_vel_parsec.rs
@@ -37,7 +37,7 @@ fn build() -> Scheduler {
             positions.insert(*e, PosComp(Position { x: 0.0, y: 0.0 }));
             velocities.insert(*e, VelComp(Velocity { dx: 0.0, dy: 0.0 }));
         }
-        for e in ents[N_POS_VEL..N_POS_VEL].iter() {
+        for e in ents[N_POS_VEL..].iter() {
             positions.insert(*e, PosComp(Position { x: 0.0, y: 0.0 }));
         }
     }


### PR DESCRIPTION
The index expression `N_POS_VEL..N_POS_VEL` was evaluating to an empty range.

before:

```
     Running target/release/pos_vel_parsec-b7919f11ef8d2aaa

running 2 tests
test bench_build  ... bench:     234,454 ns/iter (+/- 13,953)
test bench_update ... bench:     255,384 ns/iter (+/- 6,163)
```

after:

```
     Running target/release/pos_vel_parsec-b7919f11ef8d2aaa

running 2 tests
test bench_build  ... bench:     326,998 ns/iter (+/- 73,803)
test bench_update ... bench:     307,391 ns/iter (+/- 8,637)
```
