### PR TITLE
Add calx ecs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,12 @@ name = "ecs_bench"
 version = "0.1.0"
 authors = ["Lukas Schmierer <lukas.schmierer@lschmierer.de>"]
 
+[dependencies]
+rustc-serialize = "0.3"
+
 [dev-dependencies]
 ecs = "0.23.1"
 specs = "0.6"
 recs = "2.0.1"
 trex = "0.2.0"
+calx-ecs = "0.3"

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -5,12 +5,12 @@ Benchmarks are run on [Travis CI](https://travis-ci.org/lschmierer/ecs_bench/).
 
 Benchmarks are located in `benches/[bench_name]_[ecs_crate_name].rs`.
 
- Benchmark       | [ecs](https://github.com/HeroesGrave/ecs-rs) | [specs](https://github.com/slide-rs/specs) | [recs](https://github.com/andybarron/rustic-ecs) | [trex](https://github.com/rcolinray/trex)
- --------------- |:--------------------------------------------:|:------------------------------------------:|:------------------------------------------------:|:-----------------------------------------:
- pos_vel build   | {pos_vel_build_ecs}                          | {pos_vel_build_specs}                      | {pos_vel_build_recs}                             | {pos_vel_build_trex}
- pos_vel update  | {pos_vel_update_ecs}                         | {pos_vel_update_specs}                     | {pos_vel_update_recs}                            | {pos_vel_update_trex}
- parallel build  | {parallel_build_ecs}                         | {parallel_build_specs}                     | {parallel_build_recs}                            | {parallel_build_trex}
- parallel update | {parallel_update_ecs}                        | {parallel_update_specs}                    | {parallel_update_recs}                           | {parallel_update_trex}
+ Benchmark       | [ecs](https://github.com/HeroesGrave/ecs-rs) | [specs](https://github.com/slide-rs/specs) | [recs](https://github.com/andybarron/rustic-ecs) | [trex](https://github.com/rcolinray/trex) | [calx-ecs](https://github.com/rsaarelm/calx-ecs)
+ --------------- |:--------------------------------------------:|:------------------------------------------:|:------------------------------------------------:|:-----------------------------------------:|:-----------------------------------------:
+ pos_vel build   | {pos_vel_build_ecs}                          | {pos_vel_build_specs}                      | {pos_vel_build_recs}                             | {pos_vel_build_trex}                      | {pos_vel_build_calx_ecs}
+ pos_vel update  | {pos_vel_update_ecs}                         | {pos_vel_update_specs}                     | {pos_vel_update_recs}                            | {pos_vel_update_trex}                     | {pos_vel_update_calx_ecs}
+ parallel build  | {parallel_build_ecs}                         | {parallel_build_specs}                     | {parallel_build_recs}                            | {parallel_build_trex}                     | {parallel_build_calx_ecs}
+ parallel update | {parallel_update_ecs}                        | {parallel_update_specs}                    | {parallel_update_recs}                           | {parallel_update_trex}                    | {parallel_update_calx_ecs}
 
 ### pos_vel
  * 1000 entities with `position` and `velocity` components

--- a/bench_results.py
+++ b/bench_results.py
@@ -1,7 +1,7 @@
 import subprocess
 
 
-benches = ['ecs', 'specs', 'recs', 'trex']
+benches = ['ecs', 'specs', 'recs', 'trex', 'calx_ecs']
 bench_targets = ['pos_vel', 'parallel']
 bench_names = ['build', 'update']
 

--- a/benches/parallel_calx_ecs.rs
+++ b/benches/parallel_calx_ecs.rs
@@ -1,0 +1,55 @@
+#![feature(test)]
+extern crate test;
+use test::Bencher;
+
+#[macro_use]
+extern crate calx_ecs;
+extern crate rustc_serialize;
+
+extern crate ecs_bench;
+
+use calx_ecs::Entity;
+
+use ecs_bench::parallel::{R, W1, W2, N};
+
+Ecs! {
+    r: R,
+    w1: W1,
+    w2: W2,
+}
+
+fn build() -> Ecs {
+    let mut ecs = Ecs::new();
+
+    for _ in 0..N {
+        let e = ecs.make();
+        ecs.r.insert(e, R { x: 0.0 });
+        ecs.w1.insert(e, W1 { x: 0.0 });
+        ecs.w2.insert(e, W2 { x: 0.0 });
+    }
+
+    ecs
+}
+
+#[bench]
+fn bench_build(b: &mut Bencher) {
+    b.iter(|| build());
+}
+
+#[bench]
+fn bench_update(b: &mut Bencher) {
+    let mut ecs = build();
+
+    b.iter(|| {
+        let es: Vec<Entity> = ecs.r.iter().map(|(&e, _)| e).collect();
+        for &e in &es {
+            let rx = ecs.r[e].x;
+            ecs.w1.get_mut(e).map(|w1| w1.x = rx);
+        }
+
+        for &e in &es {
+            let rx = ecs.r[e].x;
+            ecs.w2.get_mut(e).map(|w2| w2.x = rx);
+        }
+    });
+}

--- a/benches/pos_vel_calx_ecs.rs
+++ b/benches/pos_vel_calx_ecs.rs
@@ -1,0 +1,62 @@
+#![feature(test)]
+extern crate test;
+use test::Bencher;
+
+#[macro_use]
+extern crate calx_ecs;
+extern crate rustc_serialize;
+
+extern crate ecs_bench;
+
+use calx_ecs::Entity;
+
+use ecs_bench::pos_vel::{Position, Velocity, N_POS_VEL, N_POS};
+
+Ecs! {
+    pos: Position,
+    vel: Velocity,
+}
+
+fn build() -> Ecs {
+    let mut ecs = Ecs::new();
+
+    // setup entities
+    for _ in 0..N_POS_VEL {
+        let e = ecs.make();
+        ecs.pos.insert(e, Position { x: 0.0, y: 0.0 });
+        ecs.vel.insert(e, Velocity { dx: 0.0, dy: 0.0 });
+    }
+    for _ in 0..N_POS {
+        let e = ecs.make();
+        ecs.pos.insert(e, Position { x: 0.0, y: 0.0 });
+    }
+
+    ecs
+}
+
+#[bench]
+fn bench_build(b: &mut Bencher) {
+    b.iter(|| build());
+}
+
+#[bench]
+fn bench_update(b: &mut Bencher) {
+    let mut ecs = build();
+
+    b.iter(|| {
+        // Update
+        let with_velocity: Vec<Entity> = ecs.vel.iter().map(|(&e, _)| e).collect();
+        for &e in &with_velocity {
+            let vel = ecs.vel[e];
+            ecs.pos.get_mut(e).map(|pos| {
+                pos.x += vel.dx;
+                pos.y += vel.dy;
+            });
+        }
+
+        // Render
+        for &e in ecs.iter() {
+            ecs.pos.get(e).map(|_pos| {});
+        }
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate rustc_serialize;
 
 pub mod pos_vel {
 
@@ -7,13 +8,13 @@ pub mod pos_vel {
     /// Entities with position component only.
     pub const N_POS: usize = 9000;
 
-    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[derive(Copy, Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
     pub struct Position {
         pub x: f32,
         pub y: f32,
     }
 
-    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[derive(Copy, Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
     pub struct Velocity {
         pub dx: f32,
         pub dy: f32,
@@ -25,17 +26,17 @@ pub mod parallel {
 
     pub const N: usize = 10000;
 
-    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[derive(Copy, Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
     pub struct R {
         pub x: f32,
     }
 
-    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[derive(Copy, Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
     pub struct W1 {
         pub x: f32,
     }
 
-    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[derive(Copy, Clone, Debug, PartialEq, RustcEncodable, RustcDecodable)]
     pub struct W2 {
         pub x: f32,
     }


### PR DESCRIPTION
Add my calx-ecs system to the suite.

Calx-ecs supports serialization, and currently it's mandatory that all components do so as well, so the components have to have serialization derives added.